### PR TITLE
feat: añadir filtro por año con opción mayor o menor en

### DIFF
--- a/code/Main.py
+++ b/code/Main.py
@@ -3,7 +3,7 @@ from Vehicle import Vehiculo
 class Main:
     def __init__(self):
         self.vehiculos = []
-       
+
     # Método para imprimir todos los vehículos registrados
     def mostrar_todos_los_vehiculos(self):
         if not self.vehiculos:
@@ -15,7 +15,7 @@ class Main:
                       f"Modelo: {vehiculo.getModelo()}\n"
                       f"Año: {vehiculo.getAño()}\n"
                       f"Kilometraje: {vehiculo.getKilometraje()}\n"
-                      f"Estado: {vehiculo.getEstadoActual()}\n"
+                      f"Estado: {vehiculo.getEstado()}\n"
                       f"Tipo de Combustible: {vehiculo.getTipoCombustible()}\n"
                       f"{'-'*30}")
 
@@ -24,17 +24,24 @@ class Main:
         self.vehiculos.append(vehiculo)
         print(f"Vehículo {vehiculo.getMarca()} {vehiculo.getModelo()} añadido correctamente.")
 
-    # Método para buscar vehículos por año
-    def buscar_vehiculos_por_año(self, año):
-        encontrados = [vehiculo for vehiculo in self.vehiculos if vehiculo.getAño() == año]
-        if encontrados:
-            print(f"Vehículos del año {año}:")
-            for vehiculo in encontrados:
-                print(f"- {vehiculo.getMarca()} {vehiculo.getModelo()}")
+    # Método para buscar vehículos por año, permite buscar antes o después del año dado
+    def buscar_vehiculos_por_año(self, año, antes_o_despues):
+        if antes_o_despues == 'antes':
+            encontrados = [vehiculo for vehiculo in self.vehiculos if vehiculo.getAño() < año]
+        elif antes_o_despues == 'despues':
+            encontrados = [vehiculo for vehiculo in self.vehiculos if vehiculo.getAño() > año]
         else:
-            print(f"No se encontraron vehículos del año {año}.")
+            print("Debe especificar 'antes' o 'despues' para el filtro.")
+            return
 
-def main():
+        if encontrados:
+            print(f"Vehículos fabricados {antes_o_despues} del año {año}:")
+            for vehiculo in encontrados:
+                print(f"- {vehiculo.getMarca()} {vehiculo.getModelo()} ({vehiculo.getAño()})")
+        else:
+            print(f"No se encontraron vehículos fabricados {antes_o_despues} del año {año}.")
+
+def ejecutar_main():
     sistema = Main()
 
     # Crear tres vehículos
@@ -47,8 +54,14 @@ def main():
     sistema.añadir_vehiculo(vehiculo2)
     sistema.añadir_vehiculo(vehiculo3)
 
-    # Buscar vehículos por año
-    sistema.buscar_vehiculos_por_año(2018)
+    # Mostrar todos los vehículos registrados
+    sistema.mostrar_todos_los_vehiculos()
+
+    # Buscar vehículos fabricados antes del 2020
+    sistema.buscar_vehiculos_por_año(2020, 'antes')
+
+    # Buscar vehículos fabricados después del 2019
+    sistema.buscar_vehiculos_por_año(2019, 'despues')
 
 if __name__ == "__main__":
-    main()
+    ejecutar_main()


### PR DESCRIPTION
Se ha modificado la funcionalidad de búsqueda de vehículos en la clase Main para permitir filtrar vehículos según su año de fabricación, especificando si se desea buscar vehículos fabricados antes o después de un año dado. Esta mejora facilita consultas más flexibles y precisas sobre los vehículos registrados en el sistema, mejorando la experiencia del usuario y optimizando el acceso a la información relevante.

Además, se ha actualizado el archivo README.md con instrucciones detalladas sobre cómo utilizar esta nueva funcionalidad.